### PR TITLE
Return error if Subscribe throws an ExecutionError

### DIFF
--- a/src/GraphQL.AspNetCore3/WebSockets/BaseSubscriptionServer.cs
+++ b/src/GraphQL.AspNetCore3/WebSockets/BaseSubscriptionServer.cs
@@ -276,6 +276,10 @@ public abstract class BaseSubscriptionServer : IOperationMessageProcessor
             }
         } catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested) {
             throw;
+        } catch (ExecutionError error) {
+            if (!Subscriptions.Contains(message.Id, dummyDisposer))
+                return;
+            await SendErrorResultAsync(message, error);
         } catch (Exception ex) {
             if (!Subscriptions.Contains(message.Id, dummyDisposer))
                 return;

--- a/src/Tests/WebSockets/BaseSubscriptionServerTests.cs
+++ b/src/Tests/WebSockets/BaseSubscriptionServerTests.cs
@@ -473,6 +473,23 @@ public class BaseSubscriptionServerTests : IDisposable
     }
 
     [Fact]
+    public async Task Subscribe_HandlesThrownExcecutionError()
+    {
+        var message = new OperationMessage { Id = "abc" };
+        var ex = new ExecutionError("sample");
+        _mockServer.Protected().Setup<Task<ExecutionResult>>("ExecuteRequestAsync", message)
+            .Returns(Task.FromException<ExecutionResult>(ex))
+            .Verifiable();
+        _mockServer.Protected().Setup<Task>("SendErrorResultAsync", message, ex)
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+        _mockServer.Protected().Setup<Task>("SubscribeAsync", message, false).Verifiable();
+        await _server.Do_SubscribeAsync(message, false);
+        _mockServer.Verify();
+        _mockServer.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public async Task Subscribe_DoesNotSendWhenDisposed()
     {
         var message = new OperationMessage { Id = "abc" };


### PR DESCRIPTION
If an exception occurs within Subscribe, and if it is handled by the unhandled exception delegate within GraphQL.NET, this patch allows the rethrown `ExecutionError` to be passed to the caller.