### PR TITLE
Add WebSocket support to IUserContextBuilder

### DIFF
--- a/src/GraphQL.AspNetCore3/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class GraphQLBuilderExtensions
                 var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
                 var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
                 var contextBuilder = requestServices.GetRequiredService<IUserContextBuilder>();
-                options.UserContext = await contextBuilder.BuildUserContextAsync(httpContext);
+                options.UserContext = await contextBuilder.BuildUserContextAsync(httpContext, null);
             }
         });
 
@@ -105,6 +105,45 @@ public static class GraphQLBuilderExtensions
                 var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
                 var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
                 options.UserContext = await creator(httpContext);
+            }
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures a delegate to be used to create a user context for each GraphQL request.
+    /// <br/><br/>
+    /// Requires <see cref="IHttpContextAccessor"/> to be registered within the dependency injection framework
+    /// if calling <see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)"/> directly.
+    /// </summary>
+    public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, object?, TUserContext> creator)
+        where TUserContext : class, IDictionary<string, object?>
+    {
+        builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>(creator ?? throw new ArgumentNullException(nameof(creator))));
+        builder.ConfigureExecutionOptions(options => {
+            if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>)) {
+                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
+                var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
+                options.UserContext = creator(httpContext, null);
+            }
+        });
+
+        return builder;
+    }
+
+    /// <inheritdoc cref="AddUserContextBuilder{TUserContext}(IGraphQLBuilder, Func{HttpContext, TUserContext})"/>
+    public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, object?, Task<TUserContext>> creator)
+        where TUserContext : class, IDictionary<string, object?>
+    {
+        if (creator == null)
+            throw new ArgumentNullException(nameof(creator));
+        builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>((context, payload) => new(creator(context, payload))));
+        builder.ConfigureExecutionOptions(async options => {
+            if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>)) {
+                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
+                var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
+                options.UserContext = await creator(httpContext, null);
             }
         });
 

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
@@ -126,6 +126,7 @@ public abstract class GraphQLHttpMiddleware
     private readonly IGraphQLTextSerializer _serializer;
     private readonly IEnumerable<IWebSocketHandler>? _webSocketHandlers;
     private readonly RequestDelegate _next;
+    private readonly IUserContextBuilder _userContextBuilderForWebSockets;
 
     private const string QUERY_KEY = "query";
     private const string VARIABLES_KEY = "variables";
@@ -152,6 +153,7 @@ public abstract class GraphQLHttpMiddleware
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         Options = options ?? throw new ArgumentNullException(nameof(options));
         _webSocketHandlers = webSocketHandlers;
+        _userContextBuilderForWebSockets = new UserContextBuilder<IDictionary<string, object?>>(BuildUserContextAsync);
     }
 
     /// <inheritdoc/>
@@ -322,7 +324,7 @@ public abstract class GraphQLHttpMiddleware
         GraphQLRequest gqlRequest)
     {
         // Normal execution with single graphql request
-        var userContext = await BuildUserContextAsync(context);
+        var userContext = await BuildUserContextAsync(context, null);
         var result = await ExecuteRequestAsync(context, gqlRequest, context.RequestServices, userContext);
         var statusCode = Options.ValidationErrorsReturnBadRequest && !result.Executed
             ? HttpStatusCode.BadRequest
@@ -338,7 +340,7 @@ public abstract class GraphQLHttpMiddleware
         RequestDelegate next,
         IList<GraphQLRequest> gqlRequests)
     {
-        var userContext = await BuildUserContextAsync(context);
+        var userContext = await BuildUserContextAsync(context, null);
         var results = new ExecutionResult[gqlRequests.Count];
         if (gqlRequests.Count == 1) {
             results[0] = await ExecuteRequestAsync(context, gqlRequests[0], context.RequestServices, userContext);
@@ -406,12 +408,12 @@ public abstract class GraphQLHttpMiddleware
     /// In this manner, both scoped and singleton <see cref="IUserContextBuilder"/>
     /// instances are supported, although singleton instances are recommended.
     /// </summary>
-    protected virtual async ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context)
+    protected virtual async ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context, object? payload)
     {
         var userContextBuilder = context.RequestServices.GetService<IUserContextBuilder>();
         var userContext = userContextBuilder == null
             ? new Dictionary<string, object?>()
-            : await userContextBuilder.BuildUserContextAsync(context);
+            : await userContextBuilder.BuildUserContextAsync(context, payload);
         return userContext;
     }
 
@@ -463,10 +465,8 @@ public abstract class GraphQLHttpMiddleware
             return;
         }
 
-        // Prepare user context
-        var userContext = await BuildUserContextAsync(context);
         // Connect, then wait until the websocket has disconnected (and all subscriptions ended)
-        await selectedHandler.ExecuteAsync(context, socket, selectedProtocol, userContext);
+        await selectedHandler.ExecuteAsync(context, socket, selectedProtocol, _userContextBuilderForWebSockets);
     }
 
     /// <summary>

--- a/src/GraphQL.AspNetCore3/IUserContextBuilder.cs
+++ b/src/GraphQL.AspNetCore3/IUserContextBuilder.cs
@@ -1,7 +1,7 @@
 namespace GraphQL.AspNetCore3;
 
 /// <summary>
-/// Creates a user context from a <see cref="HttpContext"/>.
+/// Creates a user context from a <see cref="HttpContext"/> and/or the WebSocket initialization message's payload.
 /// <br/><br/>
 /// The generated user context may be used for one or more GraphQL requests or
 /// subscriptions over the same HTTP connection.
@@ -9,5 +9,17 @@ namespace GraphQL.AspNetCore3;
 public interface IUserContextBuilder
 {
     /// <inheritdoc cref="IUserContextBuilder"/>
-    ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context);
+    /// <param name="context">The <see cref="HttpContext"/> of the HTTP connection.</param>
+    /// <param name="payload">
+    /// The payload of the WebSocket connection request, if applicable.  Typically this is either <see langword="null"/> or
+    /// an object that has not fully been deserialized yet; when using the Newtonsoft.Json deserializer, this will be a JObject,
+    /// and when using System.Text.Json this will be a <see cref="System.Text.Json.JsonElement">JsonElement</see>.  You may call
+    /// <see cref="IGraphQLSerializer.ReadNode{T}(object?)"/> to deserialize the node into the expected type.  To deserialize
+    /// into a nested set of <see cref="IDictionary{TKey, TValue}">IDictionary&lt;string, object?&gt;</see> maps, call
+    /// <see cref="IGraphQLSerializer.ReadNode{T}(object?)"/> with <see cref="Inputs"/> as the generic type.
+    /// <br/><br/>
+    /// To determine if this is a WebSocket connection request, check
+    /// <paramref name="context"/>.<see cref="HttpContext.WebSockets">WebSockets</see>.<see cref="WebSocketManager.IsWebSocketRequest">IsWebSocketRequest</see>.
+    /// </param>
+    ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context, object? payload);
 }

--- a/src/GraphQL.AspNetCore3/IWebSocketHandler.cs
+++ b/src/GraphQL.AspNetCore3/IWebSocketHandler.cs
@@ -14,7 +14,7 @@ public interface IWebSocketHandler
     /// <summary>
     /// Executes a specified WebSocket request, returning once the connection is closed.
     /// </summary>
-    Task ExecuteAsync(HttpContext httpContext, WebSocket webSocket, string subProtocol, IDictionary<string, object?> userContext);
+    Task ExecuteAsync(HttpContext httpContext, WebSocket webSocket, string subProtocol, IUserContextBuilder userContextBuilder);
 
     /// <summary>
     /// Gets a list of supported WebSocket sub-protocols.

--- a/src/GraphQL.AspNetCore3/UserContextBuilder.cs
+++ b/src/GraphQL.AspNetCore3/UserContextBuilder.cs
@@ -6,28 +6,51 @@ namespace GraphQL.AspNetCore3;
 public class UserContextBuilder<TUserContext> : IUserContextBuilder
     where TUserContext : IDictionary<string, object?>
 {
-    private readonly Func<HttpContext, ValueTask<TUserContext>> _func;
+    private readonly Func<HttpContext, object?, ValueTask<IDictionary<string, object?>>> _func;
 
     /// <summary>
     /// Initializes a new instance with the specified delegate.
     /// </summary>
     public UserContextBuilder(Func<HttpContext, ValueTask<TUserContext>> func)
     {
-        _func = func ?? throw new ArgumentNullException(nameof(func));
+        if (func == null)
+            throw new ArgumentNullException(nameof(func));
+
+        _func = async (context, payload) => await func(context);
     }
 
-    /// <summary>
-    /// Initializes a new instance with the specified delegate.
-    /// </summary>
+    /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>
     public UserContextBuilder(Func<HttpContext, TUserContext> func)
     {
         if (func == null)
             throw new ArgumentNullException(nameof(func));
 
-        _func = x => new(func(x));
+        _func = (context, payload) => new(func(context));
+    }
+
+    /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>
+    public UserContextBuilder(Func<HttpContext, object?, ValueTask<TUserContext>> func)
+    {
+        if (func == null)
+            throw new ArgumentNullException(nameof(func));
+
+        if (func is Func<HttpContext, object?, ValueTask<IDictionary<string, object?>>> func2) {
+            _func = func2;
+        } else {
+            _func = async (context, payload) => await func(context, payload);
+        }
+    }
+
+    /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>
+    public UserContextBuilder(Func<HttpContext, object?, TUserContext> func)
+    {
+        if (func == null)
+            throw new ArgumentNullException(nameof(func));
+
+        _func = (context, payload) => new(func(context, payload));
     }
 
     /// <inheritdoc/>
-    public async ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context)
-        => await _func(context);
+    public ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context, object? payload)
+        => _func(context, payload);
 }

--- a/src/GraphQL.AspNetCore3/WebSockets/GraphQLWs/SubscriptionServer.cs
+++ b/src/GraphQL.AspNetCore3/WebSockets/GraphQLWs/SubscriptionServer.cs
@@ -23,9 +23,14 @@ public class SubscriptionServer : BaseSubscriptionServer
     protected IServiceScopeFactory ServiceScopeFactory { get; }
 
     /// <summary>
-    /// Returns the user context used to execute requests.
+    /// Gets or sets the user context used to execute requests.
     /// </summary>
-    protected IDictionary<string, object?> UserContext { get; }
+    protected IDictionary<string, object?>? UserContext { get; set; }
+
+    /// <summary>
+    /// Returns the user context builder used during connection initialization.
+    /// </summary>
+    protected IUserContextBuilder UserContextBuilder { get; }
 
     /// <summary>
     /// Returns the <see cref="IGraphQLSerializer"/> used to deserialize <see cref="OperationMessage"/> payloads.
@@ -40,7 +45,7 @@ public class SubscriptionServer : BaseSubscriptionServer
     /// <param name="executer">The <see cref="IDocumentExecuter"/> to use to execute GraphQL requests.</param>
     /// <param name="serializer">The <see cref="IGraphQLSerializer"/> to use to deserialize payloads stored within <see cref="OperationMessage.Payload"/>.</param>
     /// <param name="serviceScopeFactory">A <see cref="IServiceScopeFactory"/> to create service scopes for execution of GraphQL requests.</param>
-    /// <param name="userContext">The user context to pass to the <see cref="IDocumentExecuter"/>.</param>
+    /// <param name="userContextBuilder">The user context builder used during connection initialization.</param>
     /// <param name="authenticationService">An optional service to authenticate connections.</param>
     public SubscriptionServer(
         IWebSocketConnection sendStream,
@@ -48,13 +53,13 @@ public class SubscriptionServer : BaseSubscriptionServer
         IDocumentExecuter executer,
         IGraphQLSerializer serializer,
         IServiceScopeFactory serviceScopeFactory,
-        IDictionary<string, object?> userContext,
+        IUserContextBuilder userContextBuilder,
         IWebSocketAuthenticationService? authenticationService = null)
         : base(sendStream, options)
     {
         DocumentExecuter = executer ?? throw new ArgumentNullException(nameof(executer));
         ServiceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
-        UserContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        UserContextBuilder = userContextBuilder ?? throw new ArgumentNullException(nameof(userContextBuilder));
         Serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         _authenticationService = authenticationService;
     }
@@ -172,19 +177,21 @@ public class SubscriptionServer : BaseSubscriptionServer
     {
         var request = Serializer.ReadNode<GraphQLRequest>(message.Payload)!;
         using var scope = ServiceScopeFactory.CreateScope();
-        return await DocumentExecuter.ExecuteAsync(new ExecutionOptions {
+        var options = new ExecutionOptions {
             Query = request.Query,
             Variables = request.Variables,
             Extensions = request.Extensions,
             OperationName = request.OperationName,
-            UserContext = UserContext,
             RequestServices = scope.ServiceProvider,
             CancellationToken = CancellationToken,
-        });
+        };
+        if (UserContext != null)
+            options.UserContext = UserContext;
+        return await DocumentExecuter.ExecuteAsync(options);
     }
 
     /// <summary>
-    /// Authorizes an incoming GraphQL over WebSockets request with the connection initialization message.
+    /// Authorizes an incoming GraphQL over WebSockets request with the connection initialization message and initializes the <see cref="UserContext"/>.
     /// <br/><br/>
     /// The default implementation calls the <see cref="IWebSocketAuthenticationService.AuthenticateAsync(IWebSocketConnection, string, OperationMessage)"/>
     /// method to authenticate the request, checks the authorization rules set in <see cref="GraphQLHttpMiddlewareOptions"/>,
@@ -192,6 +199,10 @@ public class SubscriptionServer : BaseSubscriptionServer
     /// to <see cref="BaseSubscriptionServer.OnNotAuthenticatedAsync(OperationMessage)">OnNotAuthenticatedAsync</see>,
     /// <see cref="BaseSubscriptionServer.OnNotAuthorizedRoleAsync(OperationMessage)">OnNotAuthorizedRoleAsync</see>
     /// or <see cref="BaseSubscriptionServer.OnNotAuthorizedPolicyAsync(OperationMessage, AuthorizationResult)">OnNotAuthorizedPolicyAsync</see>.
+    /// <br/><br/>
+    /// After successful authorization, the default implementation calls
+    /// <see cref="UserContextBuilder"/>.<see cref="IUserContextBuilder.BuildUserContextAsync(HttpContext, object?)">BuildUserContextAsync</see>
+    /// to generate a user context.
     /// <br/><br/>
     /// This method will return <see langword="true"/> if authorization is successful, or
     /// return <see langword="false"/> if not.
@@ -201,6 +212,12 @@ public class SubscriptionServer : BaseSubscriptionServer
         if (_authenticationService != null)
             await _authenticationService.AuthenticateAsync(Client, SubProtocol, message);
 
-        return await base.AuthorizeAsync(message);
+        var success = await base.AuthorizeAsync(message);
+
+        if (success) {
+            UserContext = await UserContextBuilder.BuildUserContextAsync(Client.HttpContext, message.Payload);
+        }
+
+        return success;
     }
 }

--- a/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
+++ b/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
@@ -69,6 +69,10 @@ namespace GraphQL.AspNetCore3
             where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
         public static GraphQL.DI.IGraphQLBuilder AddUserContextBuilder<TUserContext>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, TUserContext> creator)
             where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
+        public static GraphQL.DI.IGraphQLBuilder AddUserContextBuilder<TUserContext>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, System.Threading.Tasks.Task<TUserContext>> creator)
+            where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
+        public static GraphQL.DI.IGraphQLBuilder AddUserContextBuilder<TUserContext>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, TUserContext> creator)
+            where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
         public static GraphQL.DI.IGraphQLBuilder AddWebSocketAuthentication(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.AspNetCore3.WebSockets.IWebSocketAuthenticationService webSocketAuthenticationService) { }
         public static GraphQL.DI.IGraphQLBuilder AddWebSocketAuthentication(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, GraphQL.AspNetCore3.WebSockets.IWebSocketAuthenticationService> factory) { }
         public static GraphQL.DI.IGraphQLBuilder AddWebSocketAuthentication<TWebSocketAuthenticationService>(this GraphQL.DI.IGraphQLBuilder builder)

--- a/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
+++ b/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
@@ -103,7 +103,7 @@ namespace GraphQL.AspNetCore3
     {
         public GraphQLHttpMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.IGraphQLTextSerializer serializer, GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions options, System.Collections.Generic.IEnumerable<GraphQL.AspNetCore3.IWebSocketHandler>? webSocketHandlers = null) { }
         protected GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions Options { get; }
-        protected virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload) { }
         protected abstract System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.Transport.GraphQLRequest request, System.IServiceProvider serviceProvider, System.Collections.Generic.IDictionary<string, object?> userContext);
         protected abstract System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteScopedRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.Transport.GraphQLRequest request, System.Collections.Generic.IDictionary<string, object?> userContext);
         protected virtual System.Threading.Tasks.ValueTask<bool> HandleAuthorizeAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
@@ -163,12 +163,12 @@ namespace GraphQL.AspNetCore3
     }
     public interface IUserContextBuilder
     {
-        System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload);
     }
     public interface IWebSocketHandler
     {
         System.Collections.Generic.IEnumerable<string> SupportedSubProtocols { get; }
-        System.Threading.Tasks.Task ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext httpContext, System.Net.WebSockets.WebSocket webSocket, string subProtocol, System.Collections.Generic.IDictionary<string, object?> userContext);
+        System.Threading.Tasks.Task ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext httpContext, System.Net.WebSockets.WebSocket webSocket, string subProtocol, GraphQL.AspNetCore3.IUserContextBuilder userContextBuilder);
     }
     public interface IWebSocketHandler<TSchema> : GraphQL.AspNetCore3.IWebSocketHandler
         where TSchema : GraphQL.Types.ISchema { }
@@ -177,7 +177,9 @@ namespace GraphQL.AspNetCore3
     {
         public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Threading.Tasks.ValueTask<TUserContext>> func) { }
         public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, TUserContext> func) { }
-        public System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
+        public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, System.Threading.Tasks.ValueTask<TUserContext>> func) { }
+        public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, TUserContext> func) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload) { }
     }
 }
 namespace GraphQL.AspNetCore3.Errors
@@ -326,9 +328,9 @@ namespace GraphQL.AspNetCore3.WebSockets
         public WebSocketHandler(GraphQL.IGraphQLSerializer serializer, GraphQL.IDocumentExecuter executer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions options, Microsoft.Extensions.Hosting.IHostApplicationLifetime hostApplicationLifetime, GraphQL.AspNetCore3.WebSockets.IWebSocketAuthenticationService? authorizationService = null) { }
         protected GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions Options { get; }
         public virtual System.Collections.Generic.IEnumerable<string> SupportedSubProtocols { get; }
-        protected virtual GraphQL.AspNetCore3.WebSockets.IOperationMessageProcessor CreateReceiveStream(GraphQL.AspNetCore3.WebSockets.IWebSocketConnection webSocketConnection, string subProtocol, System.Collections.Generic.IDictionary<string, object?> userContext) { }
+        protected virtual GraphQL.AspNetCore3.WebSockets.IOperationMessageProcessor CreateReceiveStream(GraphQL.AspNetCore3.WebSockets.IWebSocketConnection webSocketConnection, string subProtocol, GraphQL.AspNetCore3.IUserContextBuilder userContextBuilder) { }
         protected virtual GraphQL.AspNetCore3.WebSockets.IWebSocketConnection CreateWebSocketConnection(Microsoft.AspNetCore.Http.HttpContext httpContext, System.Net.WebSockets.WebSocket webSocket, System.Threading.CancellationToken cancellationToken) { }
-        public virtual System.Threading.Tasks.Task ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext httpContext, System.Net.WebSockets.WebSocket webSocket, string subProtocol, System.Collections.Generic.IDictionary<string, object?> userContext) { }
+        public virtual System.Threading.Tasks.Task ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext httpContext, System.Net.WebSockets.WebSocket webSocket, string subProtocol, GraphQL.AspNetCore3.IUserContextBuilder userContextBuilder) { }
     }
     public class WebSocketHandler<TSchema> : GraphQL.AspNetCore3.WebSockets.WebSocketHandler, GraphQL.AspNetCore3.IWebSocketHandler, GraphQL.AspNetCore3.IWebSocketHandler<TSchema>
         where TSchema : GraphQL.Types.ISchema
@@ -353,11 +355,12 @@ namespace GraphQL.AspNetCore3.WebSockets.GraphQLWs
     public class SubscriptionServer : GraphQL.AspNetCore3.WebSockets.BaseSubscriptionServer
     {
         public const string SubProtocol = "graphql-transport-ws";
-        public SubscriptionServer(GraphQL.AspNetCore3.WebSockets.IWebSocketConnection sendStream, GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions options, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, System.Collections.Generic.IDictionary<string, object?> userContext, GraphQL.AspNetCore3.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
+        public SubscriptionServer(GraphQL.AspNetCore3.WebSockets.IWebSocketConnection sendStream, GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions options, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.AspNetCore3.IUserContextBuilder userContextBuilder, GraphQL.AspNetCore3.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
         protected GraphQL.IDocumentExecuter DocumentExecuter { get; }
         protected GraphQL.IGraphQLSerializer Serializer { get; }
         protected Microsoft.Extensions.DependencyInjection.IServiceScopeFactory ServiceScopeFactory { get; }
-        protected System.Collections.Generic.IDictionary<string, object?> UserContext { get; }
+        protected System.Collections.Generic.IDictionary<string, object?>? UserContext { get; set; }
+        protected GraphQL.AspNetCore3.IUserContextBuilder UserContextBuilder { get; }
         protected override System.Threading.Tasks.ValueTask<bool> AuthorizeAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnCompleteAsync(GraphQL.Transport.OperationMessage message) { }
@@ -390,11 +393,12 @@ namespace GraphQL.AspNetCore3.WebSockets.SubscriptionsTransportWs
     public class SubscriptionServer : GraphQL.AspNetCore3.WebSockets.BaseSubscriptionServer
     {
         public const string SubProtocol = "graphql-ws";
-        public SubscriptionServer(GraphQL.AspNetCore3.WebSockets.IWebSocketConnection sendStream, GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions options, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, System.Collections.Generic.IDictionary<string, object?> userContext, GraphQL.AspNetCore3.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
+        public SubscriptionServer(GraphQL.AspNetCore3.WebSockets.IWebSocketConnection sendStream, GraphQL.AspNetCore3.GraphQLHttpMiddlewareOptions options, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.AspNetCore3.IUserContextBuilder userContextBuilder, GraphQL.AspNetCore3.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
         protected GraphQL.IDocumentExecuter DocumentExecuter { get; }
         protected GraphQL.IGraphQLSerializer Serializer { get; }
         protected Microsoft.Extensions.DependencyInjection.IServiceScopeFactory ServiceScopeFactory { get; }
-        protected System.Collections.Generic.IDictionary<string, object?> UserContext { get; }
+        protected System.Collections.Generic.IDictionary<string, object?>? UserContext { get; set; }
+        protected GraphQL.AspNetCore3.IUserContextBuilder UserContextBuilder { get; }
         protected override System.Threading.Tasks.ValueTask<bool> AuthorizeAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task ErrorAccessDeniedAsync() { }
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }

--- a/src/Tests/BuilderMethodTests.cs
+++ b/src/Tests/BuilderMethodTests.cs
@@ -202,7 +202,7 @@ public class BuilderMethodTests
 
     private class MyUserContextBuilder : IUserContextBuilder
     {
-        public ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context)
+        public ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context, object? payload)
             => new ValueTask<IDictionary<string, object?>>(new MyUserContext { UserInfo = "fromBuilder" });
     }
 

--- a/src/Tests/UserContextBuilderTests.cs
+++ b/src/Tests/UserContextBuilderTests.cs
@@ -39,6 +39,10 @@ public class UserContextBuilderTests : IDisposable
         Should.Throw<ArgumentNullException>(() => new UserContextBuilder<MyUserContext>(func));
         Func<HttpContext, ValueTask<MyUserContext>> func2 = null!;
         Should.Throw<ArgumentNullException>(() => new UserContextBuilder<MyUserContext>(func2));
+        Func<HttpContext, object?, MyUserContext> func3 = null!;
+        Should.Throw<ArgumentNullException>(() => new UserContextBuilder<MyUserContext>(func3));
+        Func<HttpContext, object?, ValueTask<MyUserContext>> func4 = null!;
+        Should.Throw<ArgumentNullException>(() => new UserContextBuilder<MyUserContext>(func4));
     }
 
     [Fact]

--- a/src/Tests/WebSockets/NewSubscriptionServerTests.cs
+++ b/src/Tests/WebSockets/NewSubscriptionServerTests.cs
@@ -10,13 +10,13 @@ public class NewSubscriptionServerTests : IDisposable
     private readonly Mock<IDocumentExecuter> _mockDocumentExecuter = new(MockBehavior.Strict);
     private readonly Mock<IServiceScopeFactory> _mockServiceScopeFactory = new(MockBehavior.Strict);
     private readonly Mock<IGraphQLSerializer> _mockSerializer = new(MockBehavior.Strict);
-    private readonly Mock<IDictionary<string, object?>> _mockUserContext = new(MockBehavior.Strict);
+    private readonly Mock<IUserContextBuilder> _mockUserContextBuilder = new(MockBehavior.Strict);
 
     public NewSubscriptionServerTests()
     {
         _stream = _mockStream.Object;
         _mockServer = new(_stream, _options, _mockDocumentExecuter.Object, _mockSerializer.Object,
-            _mockServiceScopeFactory.Object, _mockUserContext.Object);
+            _mockServiceScopeFactory.Object, _mockUserContextBuilder.Object);
         _mockServer.CallBase = true;
     }
 
@@ -28,22 +28,22 @@ public class NewSubscriptionServerTests : IDisposable
         _server.Get_DocumentExecuter.ShouldBe(_mockDocumentExecuter.Object);
         _server.Get_Serializer.ShouldBe(_mockSerializer.Object);
         _server.Get_ServiceScopeFactory.ShouldBe(_mockServiceScopeFactory.Object);
-        _server.Get_UserContext.ShouldBe(_mockUserContext.Object);
+        _server.Get_UserContextBuilder.ShouldBe(_mockUserContextBuilder.Object);
     }
 
     [Fact]
     public void InvalidConstructorArgumentsThrows()
     {
         Should.Throw<ArgumentNullException>(() => new TestNewSubscriptionServer(_stream, _options,
-            null!, _mockSerializer.Object, _mockServiceScopeFactory.Object, _mockUserContext.Object));
+            null!, _mockSerializer.Object, _mockServiceScopeFactory.Object, _mockUserContextBuilder.Object));
         Should.Throw<ArgumentNullException>(() => new TestNewSubscriptionServer(_stream, _options,
-            _mockDocumentExecuter.Object, null!, _mockServiceScopeFactory.Object, _mockUserContext.Object));
+            _mockDocumentExecuter.Object, null!, _mockServiceScopeFactory.Object, _mockUserContextBuilder.Object));
         Should.Throw<ArgumentNullException>(() => new TestNewSubscriptionServer(_stream, _options,
-            _mockDocumentExecuter.Object, _mockSerializer.Object, null!, _mockUserContext.Object));
+            _mockDocumentExecuter.Object, _mockSerializer.Object, null!, _mockUserContextBuilder.Object));
         Should.Throw<ArgumentNullException>(() => new TestNewSubscriptionServer(_stream, _options,
             _mockDocumentExecuter.Object, _mockSerializer.Object, _mockServiceScopeFactory.Object, null!));
         _ = new TestNewSubscriptionServer(_stream, _options, _mockDocumentExecuter.Object,
-            _mockSerializer.Object, _mockServiceScopeFactory.Object, _mockUserContext.Object);
+            _mockSerializer.Object, _mockServiceScopeFactory.Object, _mockUserContextBuilder.Object);
     }
 
     [Theory]
@@ -349,6 +349,8 @@ public class NewSubscriptionServerTests : IDisposable
             .Verifiable();
         mockScope.Setup(x => x.Dispose()).Verifiable();
         var result = Mock.Of<ExecutionResult>(MockBehavior.Strict);
+        var mockUserContext = new Mock<IDictionary<string, object?>>(MockBehavior.Strict);
+        _server.Set_UserContext(mockUserContext.Object);
         _mockDocumentExecuter.Setup(x => x.ExecuteAsync(It.IsAny<ExecutionOptions>()))
             .Returns<ExecutionOptions>(options => {
                 options.ShouldNotBeNull();
@@ -356,7 +358,7 @@ public class NewSubscriptionServerTests : IDisposable
                 options.Variables.ShouldBe(request.Variables);
                 options.Extensions.ShouldBe(request.Extensions);
                 options.OperationName.ShouldBe(request.OperationName);
-                options.UserContext.ShouldBe(_mockUserContext.Object);
+                options.UserContext.ShouldBe(mockUserContext.Object);
                 options.RequestServices.ShouldBe(mockServiceProvider.Object);
                 return Task.FromResult(result);
             })
@@ -366,7 +368,7 @@ public class NewSubscriptionServerTests : IDisposable
         _mockDocumentExecuter.Verify();
         _mockSerializer.Verify();
         _mockServiceScopeFactory.Verify();
-        _mockUserContext.Verify();
+        _mockUserContextBuilder.Verify();
         mockServiceProvider.Verify();
         mockScope.Verify();
     }

--- a/src/Tests/WebSockets/TestNewSubscriptionServer.cs
+++ b/src/Tests/WebSockets/TestNewSubscriptionServer.cs
@@ -6,8 +6,8 @@ public class TestNewSubscriptionServer : SubscriptionServer
 {
     public TestNewSubscriptionServer(IWebSocketConnection sendStream, GraphQLHttpMiddlewareOptions options,
         IDocumentExecuter executer, IGraphQLSerializer serializer, IServiceScopeFactory serviceScopeFactory,
-        IDictionary<string, object?> userContext)
-        : base(sendStream, options, executer, serializer, serviceScopeFactory, userContext) { }
+        IUserContextBuilder userContextBuilder)
+        : base(sendStream, options, executer, serializer, serviceScopeFactory, userContextBuilder) { }
 
     public bool Do_TryInitialize()
         => TryInitialize();
@@ -47,7 +47,11 @@ public class TestNewSubscriptionServer : SubscriptionServer
 
     public IGraphQLSerializer Get_Serializer => Serializer;
 
-    public IDictionary<string, object?> Get_UserContext => UserContext;
+    public IDictionary<string, object?>? Get_UserContext => UserContext;
+
+    public void Set_UserContext(IDictionary<string, object?>? userContext) => UserContext = userContext;
+
+    public IUserContextBuilder Get_UserContextBuilder => UserContextBuilder;
 
     public IDocumentExecuter Get_DocumentExecuter => DocumentExecuter;
 

--- a/src/Tests/WebSockets/TestOldSubscriptionServer.cs
+++ b/src/Tests/WebSockets/TestOldSubscriptionServer.cs
@@ -6,8 +6,8 @@ public class TestOldSubscriptionServer : SubscriptionServer
 {
     public TestOldSubscriptionServer(IWebSocketConnection sendStream, GraphQLHttpMiddlewareOptions options,
         IDocumentExecuter executer, IGraphQLSerializer serializer, IServiceScopeFactory serviceScopeFactory,
-        IDictionary<string, object?> userContext)
-        : base(sendStream, options, executer, serializer, serviceScopeFactory, userContext) { }
+        IUserContextBuilder userContextBuilder)
+        : base(sendStream, options, executer, serializer, serviceScopeFactory, userContextBuilder) { }
 
     public bool Do_TryInitialize()
         => TryInitialize();
@@ -44,7 +44,11 @@ public class TestOldSubscriptionServer : SubscriptionServer
 
     public IGraphQLSerializer Get_Serializer => Serializer;
 
-    public IDictionary<string, object?> Get_UserContext => UserContext;
+    public IDictionary<string, object?>? Get_UserContext => UserContext;
+
+    public void Set_UserContext(IDictionary<string, object?>? userContext) => UserContext = userContext;
+
+    public IUserContextBuilder Get_UserContextBuilder => UserContextBuilder;
 
     public IDocumentExecuter Get_DocumentExecuter => DocumentExecuter;
 

--- a/src/Tests/WebSockets/TestWebSocketHandler.cs
+++ b/src/Tests/WebSockets/TestWebSocketHandler.cs
@@ -15,8 +15,8 @@ public class TestWebSocketHandler : WebSocketHandler
     {
     }
 
-    public IOperationMessageProcessor Do_CreateReceiveStream(IWebSocketConnection sendStream, string subProtocol, IDictionary<string, object?> userContext)
-        => CreateReceiveStream(sendStream, subProtocol, userContext);
+    public IOperationMessageProcessor Do_CreateReceiveStream(IWebSocketConnection sendStream, string subProtocol, IUserContextBuilder userContextBuilder)
+        => CreateReceiveStream(sendStream, subProtocol, userContextBuilder);
 
     public IWebSocketConnection Do_CreateWebSocketConnection(HttpContext httpContext, WebSocket webSocket, CancellationToken cancellationToken)
         => CreateWebSocketConnection(httpContext, webSocket, cancellationToken);


### PR DESCRIPTION
This changes `IUserContextBuilder` to support WebSocket connections via the graphql-ws or graphql-transport-ws subprotocol.  This is provided by:
- Adding `object? payload` to the interface method signature
- Changing the websocket support to create the user context while the initialization message is being processed, after authentication has occurred.  (Now it runs before WebSocket authentication.)

So with this change:
1. You can access `HttpContext.User` to pull properties of the user
2. You can examine any other properties of the WebSocket connection initialization message while creating the user context

Breaking changes:
- Direct implementations of `IUserContextBuilder` need to be modified

Fixes:
- `HttpContext.User` can be accessed by the user context builder for WebSocket requests

Non-breaking:
- The user context builder methods still work without changes.  New methods were added if the code needs the payload.

@sungam3r Let me know if you want to review this here.