### PR TITLE
Support media type of 'application/graphql+json'

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ A list of methods are as follows:
 | `BuildUserContextAsync`     | Builds the user context based on a `HttpContext`. |
 | `ExecuteRequestAsync`       | Executes a GraphQL request. |
 | `ExecuteScopedRequestAsync` | Executes a GraphQL request with a scoped service provider. |
+| `SelectResponseContentType` | Selects a content-type header for the JSON-formatted GraphQL response. |
 | `WriteErrorResponseAsync`   | Writes the specified error message as a JSON-formatted GraphQL response, with the specified HTTP status code. |
 | `WriteJsonResponseAsync`    | Writes the specified object (usually a GraphQL response) as JSON to the HTTP response stream. |
 

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
@@ -421,11 +421,23 @@ public abstract class GraphQLHttpMiddleware
     }
 
     /// <summary>
+    /// Selects a response content type string based on the <see cref="HttpContext"/>.
+    /// Defaults to <see cref="CONTENTTYPE_GRAPHQLJSON"/>.  Override this value for compatibility
+    /// with non-conforming GraphQL clients.
+    /// <br/><br/>
+    /// Note that by default, the response will be written as UTF-8 encoded JSON, regardless
+    /// of the content-type value here.  For more complex behavior patterns, override
+    /// <see cref="WriteJsonResponseAsync{TResult}(HttpContext, HttpStatusCode, TResult)"/>.
+    /// </summary>
+    protected virtual string SelectResponseContentType(HttpContext context)
+        => CONTENTTYPE_GRAPHQLJSON;
+
+    /// <summary>
     /// Writes the specified object (usually a GraphQL response) as JSON to the HTTP response stream.
     /// </summary>
     protected virtual Task WriteJsonResponseAsync<TResult>(HttpContext context, HttpStatusCode httpStatusCode, TResult result)
     {
-        context.Response.ContentType = CONTENTTYPE_GRAPHQLJSON;
+        context.Response.ContentType = SelectResponseContentType(context);
         context.Response.StatusCode = (int)httpStatusCode;
 
         return _serializer.WriteAsync(context.Response.Body, result, context.RequestAborted);

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
@@ -132,8 +132,10 @@ public abstract class GraphQLHttpMiddleware
     private const string VARIABLES_KEY = "variables";
     private const string EXTENSIONS_KEY = "extensions";
     private const string OPERATION_NAME_KEY = "operationName";
+    private const string MEDIATYPE_GRAPHQLJSON = "application/graphql+json";
     private const string MEDIATYPE_JSON = "application/json";
     private const string MEDIATYPE_GRAPHQL = "application/graphql";
+    private const string CONTENTTYPE_GRAPHQLJSON = "application/graphql+json; charset=utf-8";
 
     /// <summary>
     /// Gets the options configured for this instance.
@@ -196,7 +198,8 @@ public abstract class GraphQLHttpMiddleware
                 return;
             }
 
-            switch (mediaTypeHeader.MediaType) {
+            switch (mediaTypeHeader.MediaType?.ToLowerInvariant()) {
+                case MEDIATYPE_GRAPHQLJSON:
                 case MEDIATYPE_JSON:
                     IList<GraphQLRequest>? deserializationResult;
                     try {
@@ -422,7 +425,7 @@ public abstract class GraphQLHttpMiddleware
     /// </summary>
     protected virtual Task WriteJsonResponseAsync<TResult>(HttpContext context, HttpStatusCode httpStatusCode, TResult result)
     {
-        context.Response.ContentType = MEDIATYPE_JSON;
+        context.Response.ContentType = CONTENTTYPE_GRAPHQLJSON;
         context.Response.StatusCode = (int)httpStatusCode;
 
         return _serializer.WriteAsync(context.Response.Body, result, context.RequestAborted);

--- a/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
+++ b/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
@@ -126,6 +126,7 @@ namespace GraphQL.AspNetCore3
         protected virtual System.Threading.Tasks.Task HandleWebSocketAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleWebSocketSubProtocolNotSupportedAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         public virtual System.Threading.Tasks.Task InvokeAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }
         protected virtual System.Threading.Tasks.Task WriteJsonResponseAsync<TResult>(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, TResult result) { }

--- a/src/Tests/Middleware/PostTests.cs
+++ b/src/Tests/Middleware/PostTests.cs
@@ -158,12 +158,28 @@ public class PostTests : IDisposable
         await response.ShouldBeAsync(true, @"{""errors"":[{""message"":""JSON body text could not be parsed. Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed. Path: $ | LineNumber: 0 | BytePositionInLine: 1."",""extensions"":{""code"":""JSON_INVALID"",""codes"":[""JSON_INVALID""]}}]}");
     }
 
-    [Fact]
-    public async Task AltContentType()
+    [Theory]
+    [InlineData("application/graphql")]
+    [InlineData("APPLICATION/GRAPHQL")]
+    public async Task ContentType_GraphQL(string contentType)
     {
         var client = _server.CreateClient();
         var content = new StringContent("{count}");
-        content.Headers.ContentType = new("application/graphql");
+        content.Headers.ContentType = new(contentType);
+        using var response = await client.PostAsync("/graphql", content);
+        await response.ShouldBeAsync(@"{""data"":{""count"":0}}");
+    }
+
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData("application/graphql+json")]
+    [InlineData("APPLICATION/JSON")]
+    [InlineData("APPLICATION/GRAPHQL+JSON")]
+    public async Task ContentType_GraphQLJson(string contentType)
+    {
+        var client = _server.CreateClient();
+        var content = new StringContent(@"{""query"":""{count}""}");
+        content.Headers.ContentType = new(contentType);
         using var response = await client.PostAsync("/graphql", content);
         await response.ShouldBeAsync(@"{""data"":{""count"":0}}");
     }

--- a/src/Tests/ShouldlyExtensions.cs
+++ b/src/Tests/ShouldlyExtensions.cs
@@ -13,8 +13,8 @@ internal static class ShouldlyExtensions
     public static async Task ShouldBeAsync(this HttpResponseMessage message, HttpStatusCode httpStatusCode, string expectedResponse)
     {
         message.StatusCode.ShouldBe(httpStatusCode);
-        message.Content.Headers.ContentType?.MediaType.ShouldBe("application/json");
-        message.Content.Headers.ContentType?.CharSet.ShouldBeNull();
+        message.Content.Headers.ContentType?.MediaType.ShouldBe("application/graphql+json");
+        message.Content.Headers.ContentType?.CharSet.ShouldBe("utf-8");
         var actualResponse = await message.Content.ReadAsStringAsync();
         actualResponse.ShouldBe(expectedResponse);
     }


### PR DESCRIPTION
Note:
- All responses will now have the content type: `application/graphql+json; charset=utf-8`
- Since `application/graphql+json` is a subset of `application/json`, it _should_ be backwards compatible with any client.  Probably any browser client, anyway.
- `SelectResponseContentType` can be overridden to revert to old behavior.

Also:
- `application/graphql+json` is a supported content-type for incoming requests.
- Content-type header for incoming requests is now properly case insensitive

Ping @sungam3r