### PR TITLE
Support async disposable service scopes

### DIFF
--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
@@ -82,7 +82,12 @@ public class GraphQLHttpMiddleware<TSchema> : GraphQLHttpMiddleware
     protected override async Task<ExecutionResult> ExecuteScopedRequestAsync(HttpContext context, GraphQLRequest request, IDictionary<string, object?> userContext)
     {
         using var scope = _serviceScopeFactory.CreateScope();
-        return await ExecuteRequestAsync(context, request, scope.ServiceProvider, userContext);
+        try {
+            return await ExecuteRequestAsync(context, request, scope.ServiceProvider, userContext);
+        } finally {
+            if (scope is IAsyncDisposable ad)
+                await ad.DisposeAsync();
+        }
     }
 
     /// <inheritdoc/>

--- a/src/GraphQL.AspNetCore3/WebSockets/GraphQLWs/SubscriptionServer.cs
+++ b/src/GraphQL.AspNetCore3/WebSockets/GraphQLWs/SubscriptionServer.cs
@@ -177,17 +177,22 @@ public class SubscriptionServer : BaseSubscriptionServer
     {
         var request = Serializer.ReadNode<GraphQLRequest>(message.Payload)!;
         using var scope = ServiceScopeFactory.CreateScope();
-        var options = new ExecutionOptions {
-            Query = request.Query,
-            Variables = request.Variables,
-            Extensions = request.Extensions,
-            OperationName = request.OperationName,
-            RequestServices = scope.ServiceProvider,
-            CancellationToken = CancellationToken,
-        };
-        if (UserContext != null)
-            options.UserContext = UserContext;
-        return await DocumentExecuter.ExecuteAsync(options);
+        try {
+            var options = new ExecutionOptions {
+                Query = request.Query,
+                Variables = request.Variables,
+                Extensions = request.Extensions,
+                OperationName = request.OperationName,
+                RequestServices = scope.ServiceProvider,
+                CancellationToken = CancellationToken,
+            };
+            if (UserContext != null)
+                options.UserContext = UserContext;
+            return await DocumentExecuter.ExecuteAsync(options);
+        } finally {
+            if (scope is IAsyncDisposable ad)
+                await ad.DisposeAsync();
+        }
     }
 
     /// <summary>

--- a/src/GraphQL.AspNetCore3/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
+++ b/src/GraphQL.AspNetCore3/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
@@ -157,17 +157,22 @@ public class SubscriptionServer : BaseSubscriptionServer
     {
         var request = Serializer.ReadNode<GraphQLRequest>(message.Payload)!;
         using var scope = ServiceScopeFactory.CreateScope();
-        var options = new ExecutionOptions {
-            Query = request.Query,
-            Variables = request.Variables,
-            Extensions = request.Extensions,
-            OperationName = request.OperationName,
-            RequestServices = scope.ServiceProvider,
-            CancellationToken = CancellationToken,
-        };
-        if (UserContext != null)
-            options.UserContext = UserContext;
-        return await DocumentExecuter.ExecuteAsync(options);
+        try {
+            var options = new ExecutionOptions {
+                Query = request.Query,
+                Variables = request.Variables,
+                Extensions = request.Extensions,
+                OperationName = request.OperationName,
+                RequestServices = scope.ServiceProvider,
+                CancellationToken = CancellationToken,
+            };
+            if (UserContext != null)
+                options.UserContext = UserContext;
+            return await DocumentExecuter.ExecuteAsync(options);
+        } finally {
+            if (scope is IAsyncDisposable ad)
+                await ad.DisposeAsync();
+        }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Mirrors `AsyncServiceScope` struct in .NET 6.

See:
- https://github.com/dotnet/runtime/blob/aa96f04ea821effaa6cbf786c6328550f4d7ca98/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs