### PR TITLE
Return 405 Method Not Allowed for invalid request types

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -47,6 +47,9 @@ skipping fragment spreads or inline fragments via @skip and @include directives.
 Added `AuthorizationVisitorBase.GetRecursivelyReferencedFragments` which will skip
 fragment definitions not referenced due to a @skip or @include directive.
 
+Returns 405 Method Not Allowed rather than 400 Bad Request when attempting a mutation
+over a HTTP GET connection, or a subscription over a HTTP GET/POST connection.
+
 ## 3.0.0
 
 Supports building user contexts after authentication has occurred for WebSocket

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
@@ -265,9 +265,13 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
         // Normal execution with single graphql request
         var userContext = await BuildUserContextAsync(context, null);
         var result = await ExecuteRequestAsync(context, gqlRequest, context.RequestServices, userContext);
-        var statusCode = _options.ValidationErrorsReturnBadRequest && !result.Executed
-            ? HttpStatusCode.BadRequest
-            : HttpStatusCode.OK;
+        HttpStatusCode statusCode = HttpStatusCode.OK;
+        if (!result.Executed) {
+            if (result.Errors?.Any(e => e is HttpMethodValidationError) == true)
+                statusCode = HttpStatusCode.MethodNotAllowed;
+            else if (_options.ValidationErrorsReturnBadRequest)
+                statusCode = HttpStatusCode.BadRequest;
+        }
         await WriteJsonResponseAsync(context, statusCode, result);
     }
 

--- a/src/Tests/Middleware/GetTests.cs
+++ b/src/Tests/Middleware/GetTests.cs
@@ -143,7 +143,7 @@ public class GetTests : IDisposable
         _options.ValidationErrorsReturnBadRequest = badRequest;
         var client = _server.CreateClient();
         using var response = await client.GetAsync("/graphql?query=mutation{clearMessages}");
-        await response.ShouldBeAsync(badRequest, @"{""errors"":[{""message"":""Only query operations allowed for GET requests."",""locations"":[{""line"":1,""column"":1}],""extensions"":{""code"":""HTTP_METHOD_VALIDATION"",""codes"":[""HTTP_METHOD_VALIDATION""]}}]}");
+        await response.ShouldBeAsync(HttpStatusCode.MethodNotAllowed, @"{""errors"":[{""message"":""Only query operations allowed for GET requests."",""locations"":[{""line"":1,""column"":1}],""extensions"":{""code"":""HTTP_METHOD_VALIDATION"",""codes"":[""HTTP_METHOD_VALIDATION""]}}]}");
     }
 
     [Theory]
@@ -154,7 +154,7 @@ public class GetTests : IDisposable
         _options.ValidationErrorsReturnBadRequest = badRequest;
         var client = _server.CreateClient();
         using var response = await client.GetAsync("/graphql?query=subscription{newMessages{id}}");
-        await response.ShouldBeAsync(badRequest, @"{""errors"":[{""message"":""Only query operations allowed for GET requests."",""locations"":[{""line"":1,""column"":1}],""extensions"":{""code"":""HTTP_METHOD_VALIDATION"",""codes"":[""HTTP_METHOD_VALIDATION""]}}]}");
+        await response.ShouldBeAsync(HttpStatusCode.MethodNotAllowed, @"{""errors"":[{""message"":""Only query operations allowed for GET requests."",""locations"":[{""line"":1,""column"":1}],""extensions"":{""code"":""HTTP_METHOD_VALIDATION"",""codes"":[""HTTP_METHOD_VALIDATION""]}}]}");
     }
 
     [Theory]

--- a/src/Tests/Middleware/PostTests.cs
+++ b/src/Tests/Middleware/PostTests.cs
@@ -282,7 +282,7 @@ public class PostTests : IDisposable
     {
         _options.ValidationErrorsReturnBadRequest = badRequest;
         using var response = await PostRequestAsync(new() { Query = "subscription{newMessages{id}}" });
-        await response.ShouldBeAsync(badRequest, @"{""errors"":[{""message"":""Subscription operations are not supported for POST requests."",""locations"":[{""line"":1,""column"":1}],""extensions"":{""code"":""HTTP_METHOD_VALIDATION"",""codes"":[""HTTP_METHOD_VALIDATION""]}}]}");
+        await response.ShouldBeAsync(HttpStatusCode.MethodNotAllowed, @"{""errors"":[{""message"":""Subscription operations are not supported for POST requests."",""locations"":[{""line"":1,""column"":1}],""extensions"":{""code"":""HTTP_METHOD_VALIDATION"",""codes"":[""HTTP_METHOD_VALIDATION""]}}]}");
     }
 
     [Fact]


### PR DESCRIPTION
Mirrors https://github.com/graphql-dotnet/server/pull/877