### PR TITLE
Add CSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,31 +489,6 @@ app.UseEndpoints(endpoints => {
 await app.RunAsync();
 ```
 
-In order to ensure that all requests trigger CORS preflight requests, by default the server
-will reject requests that do not meet one of the following criteria:
-
-- The request is a POST request that includes a Content-Type header that is not
-  `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
-- The request includes a non-empty `GraphQL-Require-Preflight` header.
-
-To disable this behavior, set the `CsrfProtectionEnabled` option to `false` in the `GraphQLServerOptions`.
-
-```csharp
-app.UseGraphQL("/graphql", config =>
-{
-    config.CsrfProtectionEnabled = false;
-});
-```
-
-You may also change the allowed headers by modifying the `CsrfProtectionHeaders` option.
-
-```csharp
-app.UseGraphQL("/graphql", config =>
-{
-    config.CsrfProtectionHeaders = ["MyCustomHeader"];
-});
-```
-
 ### Response compression
 
 ASP.NET Core supports response compression independently of GraphQL, with brotli and gzip

--- a/README.md
+++ b/README.md
@@ -463,6 +463,31 @@ app.UseEndpoints(endpoints => {
 await app.RunAsync();
 ```
 
+In order to ensure that all requests trigger CORS preflight requests, by default the server
+will reject requests that do not meet one of the following criteria:
+
+- The request is a POST request that includes a Content-Type header that is not
+  `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
+- The request includes a non-empty `GraphQL-Require-Preflight` header.
+
+To disable this behavior, set the `CsrfProtectionEnabled` option to `false` in the `GraphQLServerOptions`.
+
+```csharp
+app.UseGraphQL("/graphql", config =>
+{
+    config.CsrfProtectionEnabled = false;
+});
+```
+
+You may also change the allowed headers by modifying the `CsrfProtectionHeaders` option.
+
+```csharp
+app.UseGraphQL("/graphql", config =>
+{
+    config.CsrfProtectionHeaders = ["MyCustomHeader"];
+});
+```
+
 ### Response compression
 
 ASP.NET Core supports response compression independently of GraphQL, with brotli and gzip
@@ -538,6 +563,8 @@ endpoint.
 | `AuthorizationRequired`            | Requires `HttpContext.User` to represent an authenticated user. | False |
 | `AuthorizedPolicy`                 | If set, requires `HttpContext.User` to pass authorization of the specified policy. | |
 | `AuthorizedRoles`                  | If set, requires `HttpContext.User` to be a member of any one of a list of roles. | |
+| `CsrfProtectionEnabled`            | Enables cross-site request forgery (CSRF) protection for both GET and POST requests. | True |
+| `CsrfProtectionHeaders`            | Sets the headers used for CSRF protection when necessary. | `GraphQL-Require-Preflight` |
 | `EnableBatchedRequests`            | Enables handling of batched GraphQL requests for POST requests when formatted as JSON. | True |
 | `ExecuteBatchedRequestsInParallel` | Enables parallel execution of batched GraphQL requests. | True |
 | `HandleGet`                        | Enables handling of GET requests. | True |

--- a/src/GraphQL.AspNetCore3/Errors/CsrfProtectionError.cs
+++ b/src/GraphQL.AspNetCore3/Errors/CsrfProtectionError.cs
@@ -1,0 +1,16 @@
+namespace GraphQL.AspNetCore3.Errors;
+
+/// <summary>
+/// Represents an error indicating that the request may not have triggered a CORS preflight request.
+/// </summary>
+public class CsrfProtectionError : RequestError
+{
+    /// <inheritdoc cref="CsrfProtectionError"/>
+    public CsrfProtectionError(IEnumerable<string> headersRequired) : base($"This request requires a non-empty header from the following list: {FormatHeaders(headersRequired)}.") { }
+
+    /// <inheritdoc cref="CsrfProtectionError"/>
+    public CsrfProtectionError(IEnumerable<string> headersRequired, Exception innerException) : base($"This request requires a non-empty header from the following list: {FormatHeaders(headersRequired)}. {innerException.Message}") { }
+
+    private static string FormatHeaders(IEnumerable<string> headersRequired)
+        => string.Join(", ", headersRequired.Select(x => $"'{x}'"));
+}

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
@@ -127,7 +127,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
         }
 
         // Perform CSRF protection if necessary
-        if (await HandleCsrfProtectionAsync(context, next))
+        if (await HandleCsrfProtectionAsync(context, _next))
             return;
 
         // Authenticate request if necessary

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddleware.cs
@@ -3,6 +3,7 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace GraphQL.AspNetCore3;
 
@@ -121,6 +122,10 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
             return;
         }
 
+        // Perform CSRF protection if necessary
+        if (await HandleCsrfProtectionAsync(context, next))
+            return;
+
         // Authenticate request if necessary
         if (await HandleAuthorizeAsync(context, _next))
             return;
@@ -232,6 +237,32 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
                 await HandleInvalidContentTypeErrorAsync(context, _next);
                 return null;
         }
+    }
+
+    /// <summary>
+    /// Performs CSRF protection, if required, and returns <see langword="true"/> if the
+    /// request was handled (typically by returning an error message).  If <see langword="false"/>
+    /// is returned, the request is processed normally.
+    /// </summary>
+    protected virtual async ValueTask<bool> HandleCsrfProtectionAsync(HttpContext context, RequestDelegate next)
+    {
+        if (!_options.CsrfProtectionEnabled)
+            return false;
+        if (context.Request.Headers.TryGetValue("Content-Type", out var contentTypes) && contentTypes.Count > 0 && contentTypes[0] != null) {
+            var contentType = contentTypes[0]!;
+            if (contentType.IndexOf(';') > 0) {
+                contentType = contentType.Substring(0, contentType.IndexOf(';'));
+            }
+            contentType = contentType.Trim().ToLowerInvariant();
+            if (!(contentType == "text/plain" || contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data"))
+                return false;
+        }
+        foreach (var header in _options.CsrfProtectionHeaders) {
+            if (context.Request.Headers.TryGetValue(header, out var values) && values.Count > 0 && values[0]?.Length > 0)
+                return false;
+        }
+        await HandleCsrfProtectionErrorAsync(context, next);
+        return true;
     }
 
     /// <summary>
@@ -580,21 +611,29 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     /// </summary>
     protected virtual async ValueTask<bool> HandleDeserializationErrorAsync(HttpContext context, RequestDelegate next, Exception exception)
     {
-        await WriteErrorResponseAsync(context, HttpStatusCode.BadRequest, new JsonInvalidError(exception));
+        await WriteErrorResponseAsync(context, new JsonInvalidError(exception));
         return true;
+    }
+
+    /// <summary>
+    /// Writes a '.' message to the output.
+    /// </summary>
+    protected virtual async Task HandleCsrfProtectionErrorAsync(HttpContext context, RequestDelegate next)
+    {
+        await WriteErrorResponseAsync(context, new CsrfProtectionError(_options.CsrfProtectionHeaders));
     }
 
     /// <summary>
     /// Writes a '400 Batched requests are not supported.' message to the output.
     /// </summary>
     protected virtual Task HandleBatchedRequestsNotSupportedAsync(HttpContext context, RequestDelegate next)
-        => WriteErrorResponseAsync(context, HttpStatusCode.BadRequest, new BatchedRequestsNotSupportedError());
+        => WriteErrorResponseAsync(context, new BatchedRequestsNotSupportedError());
 
     /// <summary>
     /// Writes a '400 Invalid requested WebSocket sub-protocol(s).' message to the output.
     /// </summary>
     protected virtual Task HandleWebSocketSubProtocolNotSupportedAsync(HttpContext context, RequestDelegate next)
-        => WriteErrorResponseAsync(context, HttpStatusCode.BadRequest, new WebSocketSubProtocolNotSupportedError(context.WebSockets.WebSocketRequestedProtocols));
+        => WriteErrorResponseAsync(context, new WebSocketSubProtocolNotSupportedError(context.WebSockets.WebSocketRequestedProtocols));
 
     /// <summary>
     /// Writes a '415 Invalid Content-Type header: could not be parsed.' message to the output.
@@ -618,6 +657,12 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
         //return WriteErrorResponseAsync(context, $"Invalid HTTP method.{(Options.HandleGet || Options.HandlePost ? $" Only {(Options.HandleGet && Options.HandlePost ? "GET and POST are" : Options.HandleGet ? "GET is" : "POST is")} supported." : "")}", HttpStatusCode.MethodNotAllowed);
         return next(context);
     }
+
+    /// <summary>
+    /// Writes the specified error as a JSON-formatted GraphQL response.
+    /// </summary>
+    protected virtual Task WriteErrorResponseAsync(HttpContext context, ExecutionError executionError)
+        => WriteErrorResponseAsync(context, executionError is IHasPreferredStatusCode withCode ? withCode.PreferredStatusCode : HttpStatusCode.BadRequest, executionError);
 
     /// <summary>
     /// Writes the specified error message as a JSON-formatted GraphQL response, with the specified HTTP status code.

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddlewareOptions.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddlewareOptions.cs
@@ -67,7 +67,7 @@ public class GraphQLHttpMiddlewareOptions : IAuthorizationOptions
     /// present, or a POST request with a Content-Type header that is not <c>text/plain</c>,
     /// <c>application/x-www-form-urlencoded</c>, or <c>multipart/form-data</c>.
     /// </summary>
-    public bool CsrfProtectionEnabled { get; set; } = true;
+    public bool CsrfProtectionEnabled { get; set; }
 
     /// <summary>
     /// When <see cref="CsrfProtectionEnabled"/> is enabled, requests require a non-empty

--- a/src/GraphQL.AspNetCore3/GraphQLHttpMiddlewareOptions.cs
+++ b/src/GraphQL.AspNetCore3/GraphQLHttpMiddlewareOptions.cs
@@ -49,6 +49,22 @@ public class GraphQLHttpMiddlewareOptions : IAuthorizationOptions
     public bool ReadQueryStringOnPost { get; set; } = true;
 
     /// <summary>
+    /// Enables cross-site request forgery (CSRF) protection for both GET and POST requests.
+    /// Requires a non-empty header from the <see cref="CsrfProtectionHeaders"/> list to be
+    /// present, or a POST request with a Content-Type header that is not <c>text/plain</c>,
+    /// <c>application/x-www-form-urlencoded</c>, or <c>multipart/form-data</c>.
+    /// </summary>
+    public bool CsrfProtectionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// When <see cref="CsrfProtectionEnabled"/> is enabled, requests require a non-empty
+    /// header from this list or a POST request with a Content-Type header that is not
+    /// <c>text/plain</c>, <c>application/x-www-form-urlencoded</c>, or <c>multipart/form-data</c>.
+    /// Defaults to <c>GraphQL-Require-Preflight</c>.
+    /// </summary>
+    public List<string> CsrfProtectionHeaders { get; set; } = new() { "GraphQL-Require-Preflight" }; // see https://github.com/graphql/graphql-over-http/pull/303
+
+    /// <summary>
     /// Enables reading variables from the query string.
     /// Variables are interpreted as JSON and deserialized before being
     /// provided to the <see cref="IDocumentExecuter"/>.

--- a/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
+++ b/src/Tests.ApiApprovals/GraphQL.AspNetCore3.approved.txt
@@ -132,6 +132,8 @@ namespace GraphQL.AspNetCore3
         protected virtual System.Threading.Tasks.Task HandleBatchRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?> gqlRequests) { }
         protected virtual System.Threading.Tasks.Task HandleBatchedRequestsNotSupportedAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleContentTypeCouldNotBeParsedErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.ValueTask<bool> HandleCsrfProtectionAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.Task HandleCsrfProtectionErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.ValueTask<bool> HandleDeserializationErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Exception exception) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidContentTypeErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidHttpMethodErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
@@ -147,6 +149,7 @@ namespace GraphQL.AspNetCore3
                 "BatchRequest"})]
         protected virtual System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Transport.GraphQLRequest?, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?>?>?> ReadPostContentAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding) { }
         protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }
         protected virtual System.Threading.Tasks.Task WriteJsonResponseAsync<TResult>(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, TResult result) { }
@@ -158,6 +161,8 @@ namespace GraphQL.AspNetCore3
         public bool AuthorizationRequired { get; set; }
         public string? AuthorizedPolicy { get; set; }
         public System.Collections.Generic.List<string> AuthorizedRoles { get; set; }
+        public bool CsrfProtectionEnabled { get; set; }
+        public System.Collections.Generic.List<string> CsrfProtectionHeaders { get; set; }
         public bool EnableBatchedRequests { get; set; }
         public bool ExecuteBatchedRequestsInParallel { get; set; }
         public bool HandleGet { get; set; }
@@ -223,6 +228,11 @@ namespace GraphQL.AspNetCore3.Errors
     public class BatchedRequestsNotSupportedError : GraphQL.Execution.RequestError
     {
         public BatchedRequestsNotSupportedError() { }
+    }
+    public class CsrfProtectionError : GraphQL.Execution.RequestError
+    {
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired) { }
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired, System.Exception innerException) { }
     }
     public class FileCountExceededError : GraphQL.Execution.RequestError, GraphQL.AspNetCore3.Errors.IHasPreferredStatusCode
     {


### PR DESCRIPTION
Requires CORS preflight requests by ensuring that the requests are not 'simple' - e.g. GET request or form-POST requests - or that a specific header has been added to the request.

See similar logic: https://www.apollographql.com/docs/apollo-server/security/cors/#preventing-cross-site-request-forgery-csrf

The chosen default header was based on the current proposal by the GraphQL working group.  See:
- https://github.com/graphql/graphql-over-http/pull/303