### PR TITLE
Discard messages sent after the close message has been posted to the queue

### DIFF
--- a/src/GraphQL.AspNetCore3/WebSockets/WebSocketConnection.cs
+++ b/src/GraphQL.AspNetCore3/WebSockets/WebSocketConnection.cs
@@ -169,7 +169,9 @@ public class WebSocketConnection : IWebSocketConnection
     /// <inheritdoc/>
     public Task SendMessageAsync(OperationMessage message)
     {
-        _pump.Post(new Message { OperationMessage = message });
+        // Messages posted after requesting the connection be closed will be discarded.
+        if (!_closeRequested)
+            _pump.Post(new Message { OperationMessage = message });
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
No behavioral change, as HandleOutgoingMessageAsync already does this, just after the message has been dequeued.