### PR TITLE
Support [AllowAnonymous] and [Authorize] simultaneously on a field

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ Both roles and policies are supported for output graph types, fields on output g
 and query arguments.  If multiple policies are specified, all must match; if multiple roles
 are specified, any one role must match.  You may also use `.Authorize()` or the
 `[Authorize]` attribute to validate that the user has authenticated.  You may also use
-`.AllowAnonymous()` and `[AllowAnonymous]` to allow fields to be returned to
-unauthenticated users within an graph that has an authorization requirement defined.
+`.AllowAnonymous()` and/or `[AllowAnonymous]` to allow fields to bypass authorization
+requirements defined on the type that contains the field.
 
 Please note that authorization rules do not apply to values returned within introspection requests,
 potentially leaking information about protected areas of the schema to unauthenticated users.

--- a/src/GraphQL.AspNetCore3/AuthorizationVisitorBase.cs
+++ b/src/GraphQL.AspNetCore3/AuthorizationVisitorBase.cs
@@ -57,9 +57,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
                     _onlyAnonymousSelected.Push(ti);
 
                     // Fields, unlike types, are validated immediately.
-                    if (!fieldAnonymousAllowed) {
-                        await ValidateAsync(field, node, context);
-                    }
+                    await ValidateAsync(field, node, context);
                 }
 
                 // prep for descendants, if any

--- a/src/Tests/AuthorizationTests.cs
+++ b/src/Tests/AuthorizationTests.cs
@@ -751,6 +751,37 @@ public class AuthorizationTests
             actual.ShouldBe(@"{""errors"":[{""message"":""Access denied for field \u0027parent\u0027 on type \u0027QueryType\u0027."",""locations"":[{""line"":1,""column"":3}],""extensions"":{""code"":""ACCESS_DENIED"",""codes"":[""ACCESS_DENIED""]}}]}");
     }
 
+    [Theory]
+    [InlineData("Role1", false, false)] // User with Role1, child requires Role2 - should fail at child level
+    [InlineData("Role2", false, false)] // User with Role2, query requires Role1 - should fail at query level
+    [InlineData("Role1,Role2", false, true)] // User with both roles - should pass
+    [InlineData(null, false, false)]    // Unauthenticated user - should fail at query level
+    [InlineData("Role1", true, false)]  // User with Role1, child requires Role2 and is anonymous - should fail
+    [InlineData("Role2", true, true)]   // User with Role2, child requires Role2 and is anonymous - should pass
+    [InlineData("Role1,Role2", true, true)] // User with both roles, child is anonymous - should pass
+    [InlineData(null, true, false)]     // Unauthenticated user, child is anonymous - should fail due as Role2 missing
+    public void BothAnonymousAndRequirements(string? userRoles, bool childIsAnonymous, bool expectedIsValid)
+    {
+        // Set up query to require Role1
+        _query.AuthorizeWithRoles("Role1");
+        
+        // Set up child field to require Role2 and optionally be anonymous
+        _field.AuthorizeWithRoles("Role2");
+        if (childIsAnonymous)
+            _field.AllowAnonymous();
+
+        // Set up user principal based on test parameters
+        if (userRoles != null)
+        {
+            var roles = userRoles.Split(',');
+            var claims = roles.Select(role => new Claim(ClaimTypes.Role, role)).ToArray();
+            _principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Cookie"));
+        }
+
+        var ret = Validate(@"{ parent { child } }");
+        ret.IsValid.ShouldBe(expectedIsValid);
+    }
+
     public enum Mode
     {
         None,

--- a/src/Tests/AuthorizationTests.cs
+++ b/src/Tests/AuthorizationTests.cs
@@ -764,15 +764,14 @@ public class AuthorizationTests
     {
         // Set up query to require Role1
         _query.AuthorizeWithRoles("Role1");
-        
+
         // Set up child field to require Role2 and optionally be anonymous
         _field.AuthorizeWithRoles("Role2");
         if (childIsAnonymous)
             _field.AllowAnonymous();
 
         // Set up user principal based on test parameters
-        if (userRoles != null)
-        {
+        if (userRoles != null) {
             var roles = userRoles.Split(',');
             var claims = roles.Select(role => new Claim(ClaimTypes.Role, role)).ToArray();
             _principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Cookie"));

--- a/src/Tests/AuthorizationTests.cs
+++ b/src/Tests/AuthorizationTests.cs
@@ -759,7 +759,7 @@ public class AuthorizationTests
     [InlineData("Role1", true, false)]  // User with Role1, child requires Role2 and is anonymous - should fail
     [InlineData("Role2", true, true)]   // User with Role2, child requires Role2 and is anonymous - should pass
     [InlineData("Role1,Role2", true, true)] // User with both roles, child is anonymous - should pass
-    [InlineData(null, true, false)]     // Unauthenticated user, child is anonymous - should fail due as Role2 missing
+    [InlineData(null, true, false)]     // Unauthenticated user, child is anonymous - should fail as Role2 is missing
     public void BothAnonymousAndRequirements(string? userRoles, bool childIsAnonymous, bool expectedIsValid)
     {
         // Set up query to require Role1


### PR DESCRIPTION
This allows bypassing parent type's authorization while defining new requirements on the field.  Previously any requirements on the field were ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved authorization validation to ensure all fields are consistently validated, regardless of anonymous access settings.

- **Tests**
	- Added comprehensive tests to verify authorization behavior when both parent and child fields have role-based requirements and varying anonymous access configurations.

- **Documentation**
	- Clarified authorization attribute descriptions to specify that they bypass type-level requirements rather than simply allowing unauthenticated access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->